### PR TITLE
Fix vignette config

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -15,6 +15,8 @@ import me.jellysquid.mods.sodium.client.render.chunk.backends.multidraw.Multidra
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraftforge.client.GuiIngameForge;
+
 import org.lwjgl.opengl.Display;
 
 import java.util.ArrayList;
@@ -199,12 +201,12 @@ public class SodiumGameOptionPages {
                         .setName(new TextComponentTranslation("sodium.options.vignette.name"))
                         .setTooltip(new TextComponentTranslation("sodium.options.vignette.tooltip"))
                         .setControl(TickBoxControl::new)
-                        .setBinding((opts, value) -> opts.quality.enableVignette = value, opts -> opts.quality.enableVignette)
+                        .setBinding((opts, value) -> GuiIngameForge.renderVignette = value, opts -> GuiIngameForge.renderVignette)
                         .setImpact(OptionImpact.LOW)
                         .build())
                 .build());
 
-
+                
         groups.add(OptionGroup.createBuilder()
                 .add(OptionImpl.createBuilder(int.class, vanillaOpts)
                         .setName(new TextComponentTranslation("options.mipmapLevels"))

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -201,7 +201,7 @@ public class SodiumGameOptionPages {
                         .setName(new TextComponentTranslation("sodium.options.vignette.name"))
                         .setTooltip(new TextComponentTranslation("sodium.options.vignette.tooltip"))
                         .setControl(TickBoxControl::new)
-                        .setBinding((opts, value) -> GuiIngameForge.renderVignette = value, opts -> GuiIngameForge.renderVignette)
+                        .setBinding((opts, value) -> opts.quality.enableVignette = value, opts -> opts.quality.enableVignette)
                         .setImpact(OptionImpact.LOW)
                         .build())
                 .build());

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -206,7 +206,7 @@ public class SodiumGameOptionPages {
                         .build())
                 .build());
 
-                
+
         groups.add(OptionGroup.createBuilder()
                 .add(OptionImpl.createBuilder(int.class, vanillaOpts)
                         .setName(new TextComponentTranslation("options.mipmapLevels"))

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -53,7 +53,7 @@ public class SodiumGameOptions {
         public int biomeBlendRadius = 2;
         public float entityDistanceScaling = 1.0F;
 
-        // public boolean enableVignette = true; //replaced by `GuiIngameForge.renderVignette`
+        public boolean enableVignette = true;
         public boolean enableClouds = true;
 
         public LightingQuality smoothLighting = LightingQuality.HIGH;

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -53,7 +53,7 @@ public class SodiumGameOptions {
         public int biomeBlendRadius = 2;
         public float entityDistanceScaling = 1.0F;
 
-        public boolean enableVignette = true;
+        // public boolean enableVignette = true; //replaced by `GuiIngameForge.renderVignette`
         public boolean enableClouds = true;
 
         public LightingQuality smoothLighting = LightingQuality.HIGH;

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinInGameHud.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinInGameHud.java
@@ -1,7 +1,8 @@
 package me.jellysquid.mods.sodium.mixin.features.options;
 
-import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import net.minecraft.client.gui.GuiIngame;
+import net.minecraftforge.client.GuiIngameForge;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -10,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public class MixinInGameHud {
     @Redirect(method = "renderGameOverlay", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;isFancyGraphicsEnabled()Z"))
     private boolean redirectFancyGraphicsVignette() {
-        return SodiumClientMod.options().quality.enableVignette;
+        // return SodiumClientMod.options().quality.enableVignette;
+        return GuiIngameForge.renderVignette;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinInGameHud.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinInGameHud.java
@@ -7,11 +7,15 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+/**
+ * note that both {@link net.minecraft.client.gui.GuiIngame} and {@link net.minecraftforge.client.GuiIngameForge}
+ * implements client GUI rendering, and mixins here can be totally useless since GuiIngame might be intentionally
+ * ignored and barely invoked
+ */
 @Mixin(GuiIngame.class)
 public class MixinInGameHud {
     @Redirect(method = "renderGameOverlay", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;isFancyGraphicsEnabled()Z"))
     private boolean redirectFancyGraphicsVignette() {
-        // return SodiumClientMod.options().quality.enableVignette;
         return GuiIngameForge.renderVignette;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinInGameHud.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinInGameHud.java
@@ -1,6 +1,6 @@
 package me.jellysquid.mods.sodium.mixin.features.options;
 
-import net.minecraft.client.gui.GuiIngame;
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import net.minecraftforge.client.GuiIngameForge;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -9,13 +9,13 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
  * note that both {@link net.minecraft.client.gui.GuiIngame} and {@link net.minecraftforge.client.GuiIngameForge}
- * implements client GUI rendering, and mixins here can be totally useless since GuiIngame might be intentionally
+ * implements client GUI rendering, and mixins for GuiIngame can be totally useless since GuiIngame might be intentionally
  * ignored and barely invoked
  */
-@Mixin(GuiIngame.class)
+@Mixin(GuiIngameForge.class)
 public class MixinInGameHud {
     @Redirect(method = "renderGameOverlay", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;isFancyGraphicsEnabled()Z"))
-    private boolean redirectFancyGraphicsVignette() {
-        return GuiIngameForge.renderVignette;
+    private boolean vintagium$redirectVignette() {
+        return SodiumClientMod.options().quality.enableVignette;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinInGameHud.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinInGameHud.java
@@ -9,13 +9,16 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
  * note that both {@link net.minecraft.client.gui.GuiIngame} and {@link net.minecraftforge.client.GuiIngameForge}
- * implements client GUI rendering, and mixins for GuiIngame can be totally useless since GuiIngame might be intentionally
- * ignored and barely invoked
+ * implements client GUI rendering, and mixins for GuiIngame can be totally useless since GuiIngame might be
+ * intentionally ignored and barely invoked
  */
 @Mixin(GuiIngameForge.class)
 public class MixinInGameHud {
     @Redirect(method = "renderGameOverlay", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;isFancyGraphicsEnabled()Z"))
     private boolean vintagium$redirectVignette() {
+        //mixin target is `if (renderVignette && Minecraft.isFancyGraphicsEnabled())`
+        //we assume that `renderVignette` is always true, because vanilla/forge will not change its value, and mods that
+        //will change it explicitly must have a reason.
         return SodiumClientMod.options().quality.enableVignette;
     }
 }


### PR DESCRIPTION
I made this PR because the "toggle vignette" config is not taking effect, and vignette is always being rendered. 

That's because Vintagium mixins into `net.minecraft.client.gui.GuiIngame` for vignette control, but there's another class that implements vignette rendering: `net.minecraftforge.client.GuiIngameForge`, and basically fully replaces `GuiIngame`. 

~~GuiIngameForge provides a convinent static config for vignette control, so we can directly hooks into forge config instead of using our own config.~~ Using Mixin for control over vignette rendering. 

example build: https://github.com/ZZZank/sodium-1.12/actions/runs/9153698174

## Testing
|vignette option|original|patched|
|-|-|-|
|on|the same as original-off|![pr-on](https://github.com/Asek3/sodium-1.12/assets/47418975/cf348075-2aa8-49e6-a256-96cfd271971a)|
|off|![original](https://github.com/Asek3/sodium-1.12/assets/47418975/d7f14c62-dabe-424e-b9f5-96b376d41189)|![pr-off](https://github.com/Asek3/sodium-1.12/assets/47418975/3cba9658-22b1-4d94-b640-9738b4d44fc3)|
