### PR TITLE
Fix Immersive Engineering Redstone connectors missing their color

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     //implementation rfg.deobf("curse.maven:thermfound-222880:2926428")
     //implementation rfg.deobf("curse.maven:thermdyn-227443:2920505")
     //implementation rfg.deobf("curse.maven:ae2-223794:2747063")
+    //implementation rfg.deobf("curse.maven:ie-231951:2974106")
 }
 
 jar {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
@@ -112,7 +112,9 @@ public class BlockRenderer {
             lighter.calculate((ModelQuadView) quad, pos, light, cullFace, quadFace, quad.shouldApplyDiffuseLighting());
 
             if (quad.hasTintIndex() && colorizer == null) {
-                colorizer = this.blockColors.getColorProvider(state);
+                if (this.blockColors.hasColorProvider(state)) {
+                    colorizer = this.blockColors.getColorProvider(state);
+                }
             }
 
             this.renderQuad(world, state, pos, sink, offset, colorizer, quad, light, renderData);
@@ -129,7 +131,7 @@ public class BlockRenderer {
 
         int[] colors = null;
 
-        if (bakedQuad.hasTintIndex()) {
+        if (bakedQuad.hasTintIndex() && colorProvider != null) {
             colors = this.biomeColorBlender.getColors(colorProvider, world, state, pos, src);
         }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/biome/BlockColorsExtended.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/biome/BlockColorsExtended.java
@@ -5,4 +5,5 @@ import net.minecraft.client.renderer.color.IBlockColor;
 
 public interface BlockColorsExtended {
     IBlockColor getColorProvider(IBlockState state);
+    boolean hasColorProvider(IBlockState state);
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/MixinBlockColors.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/MixinBlockColors.java
@@ -41,4 +41,9 @@ public class MixinBlockColors implements BlockColorsExtended {
     public IBlockColor getColorProvider(IBlockState state) {
         return this.blocksToColor.get(state.getBlock());
     }
+
+    @Override
+    public boolean hasColorProvider(IBlockState state) {
+        return this.blocksToColor.get(state.getBlock()) != DEFAULT_PROVIDER;
+    }
 }


### PR DESCRIPTION
Fixes the default color provider overwriting the vertex color of the quads if there isnt a color provider for that block.

Fixes #12