### PR TITLE
Dynamic max GUI scale + minor fixes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8
       - name: Build artifacts
         run: ./gradlew build publishMods -Pbuild.release=true
       - name: Upload assets to GitHub
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@v3.0
         with:
           # Filter built files to disregard -sources and -dev, and leave only the minecraft-compatible jars.
           files: 'build/libs/*[0-9].jar;LICENSE'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -15,7 +15,6 @@ import me.jellysquid.mods.sodium.client.render.chunk.backends.multidraw.Multidra
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentTranslation;
-import net.minecraftforge.client.GuiIngameForge;
 
 import org.lwjgl.opengl.Display;
 
@@ -53,11 +52,12 @@ public class SodiumGameOptionPages {
                         .build())
                 .build());
 
+        int maxGuiScale = Math.max(3, Math.min(Minecraft.getMinecraft().displayWidth / 320, Minecraft.getMinecraft().displayHeight / 240));
         groups.add(OptionGroup.createBuilder()
                 .add(OptionImpl.createBuilder(int.class, vanillaOpts)
                         .setName(new TextComponentTranslation("options.guiScale"))
                         .setTooltip(new TextComponentTranslation("sodium.options.gui_scale.tooltip"))
-                        .setControl(option -> new SliderControl(option, 0, 3, 1, ControlValueFormatter.guiScale()))
+                        .setControl(option -> new SliderControl(option, 0, maxGuiScale, 1, ControlValueFormatter.guiScale()))
                         .setBinding((opts, value) -> {
                             opts.guiScale = value;
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinChunkBuilder.java
@@ -19,7 +19,7 @@ public class MixinChunkBuilder {
     @Mutable
     private int countRenderBuilders;
 
-    @Redirect(method = "<init>(I)V", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/Queues;newArrayBlockingQueue(I)Ljava/util/concurrent/ArrayBlockingQueue;"))
+    @Redirect(method = "<init>(I)V", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/Queues;newArrayBlockingQueue(I)Ljava/util/concurrent/ArrayBlockingQueue;", remap = false))
     public ArrayBlockingQueue<?> modifyThreadPoolSize(int capacity) {
         // Do not allow any resources to be allocated
         this.countRenderBuilders = 0;

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/debug/MixinDebugHud.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/debug/MixinDebugHud.java
@@ -23,7 +23,7 @@ public abstract class MixinDebugHud {
         throw new UnsupportedOperationException();
     }
 
-    @Redirect(method = "getDebugInfoRight", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/Lists;newArrayList([Ljava/lang/Object;)Ljava/util/ArrayList;"))
+    @Redirect(method = "getDebugInfoRight", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/Lists;newArrayList([Ljava/lang/Object;)Ljava/util/ArrayList;", remap = false))
     private ArrayList<String> redirectRightTextEarly(Object[] elements) {
         ArrayList<String> strings = Lists.newArrayList((String[]) elements);
         strings.add("");


### PR DESCRIPTION
The maximum value of the "GUI scale" slider in Vintagium's options menu is now dynamic based on screen size. (taken from Angelica)

`remap = false` has been added to `@At` annotations where missing, which silences a few compile-time warnings.

The dependencies of the GitHub Actions workflows have been updated.

Succeeds #59