### PR TITLE
Fluidlogged API support + fluid-related bug fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,12 @@ repositories {
             includeGroup "curse.maven"
         }
     }
+    maven {
+        url 'https://api.modrinth.com/maven'
+        content {
+            includeGroup 'maven.modrinth'
+        }
+    }
 }
 
 dependencies {
@@ -56,6 +62,7 @@ dependencies {
     implementation rfg.deobf("curse.maven:codechicken-lib-1-8-242818:2779848")
     implementation rfg.deobf("curse.maven:censoredasm-460609:4800875")
     implementation rfg.deobf("curse.maven:fermiumasm-971247:5116326")
+    implementation rfg.deobf("maven.modrinth:fluidlogged-api:3.0.0") // minimum supported version
 
     // testing
     //implementation rfg.deobf("curse.maven:enderio-64578:4674244")

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -1,13 +1,13 @@
 package me.jellysquid.mods.sodium.client;
 
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
-import net.minecraft.client.Minecraft;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@Mod(modid = SodiumClientMod.MODID, useMetadata = true)
+@Mod(modid = SodiumClientMod.MODID, useMetadata = true, dependencies = ""
++ "after:fluidlogged_api@[3.0.0,);") // minimum supported mod versions
 public class SodiumClientMod {
 
     public static final String MODID = "vintagium";
@@ -34,7 +34,7 @@ public class SodiumClientMod {
     }
 
     private static SodiumGameOptions loadConfig() {
-        return SodiumGameOptions.load(Minecraft.getMinecraft().gameDir.toPath().resolve("config").resolve(MODID + "-options.json"));
+        return SodiumGameOptions.load(Loader.instance().getConfigDir().toPath().resolve(MODID + "-options.json"));
     }
 
     public static String getVersion() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
@@ -14,7 +14,6 @@ import me.jellysquid.mods.sodium.client.util.MathUtil;
 import me.jellysquid.mods.sodium.client.util.task.CancellationSource;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
 import me.jellysquid.mods.sodium.client.world.cloned.ChunkRenderContext;
-import me.jellysquid.mods.sodium.common.util.WorldUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -33,9 +32,9 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.WorldType;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.fluids.IFluidBlock;
 import org.embeddedt.embeddium.api.ChunkDataBuiltEvent;
 import org.embeddedt.embeddium.compat.ccl.CCLCompat;
+import org.embeddedt.embeddium.compat.fluidlogged_api.FluidloggedCompat;
 
 /**
  * Rebuilds all the meshes of a chunk for each given render pass with non-occluded blocks. The result is then uploaded
@@ -125,7 +124,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
 
                                 if (CCLCompat.canHandle(renderType)) {
                                     CCLCompat.renderBlock(slice, pos, blockState, buffers.get(layer));
-                                } else if (renderType == EnumBlockRenderType.MODEL && WorldUtil.toFluidBlock(block) == null) {
+                                } else if (renderType == EnumBlockRenderType.MODEL) {
                                     IBakedModel model = cache.getBlockModels()
                                             .getModelForState(blockState);
 
@@ -135,12 +134,16 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
                                         bounds.addBlock(relX, relY, relZ);
                                     }
 
-                                } else if (WorldUtil.toFluidBlock(block) != null) {
+                                } else if (renderType == EnumBlockRenderType.LIQUID) {
                                     if (cache.getFluidRenderer().render(cache.getLocalSlice(), blockState, pos, buffers.get(layer))) {
                                         bounds.addBlock(relX, relY, relZ);
                                     }
                                 }
                             }
+                        }
+
+                        if (FluidloggedCompat.IS_LOADED && FluidloggedCompat.renderFluidState(slice, relX + 16, relY + 16, relZ + 16, pos, blockState, cache, buffers)) {
+                            bounds.addBlock(relX, relY, relZ);
                         }
 
                         if (block.hasTileEntity(blockState)) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
@@ -18,7 +18,6 @@ import me.jellysquid.mods.sodium.client.util.color.ColorABGR;
 import me.jellysquid.mods.sodium.client.world.biome.BlockColorsExtended;
 import me.jellysquid.mods.sodium.common.util.DirectionUtil;
 import me.jellysquid.mods.sodium.common.util.WorldUtil;
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
@@ -26,18 +25,13 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.color.BlockColors;
 import net.minecraft.client.renderer.color.IBlockColor;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.init.Blocks;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidRegistry;
-import net.minecraftforge.fluids.IFluidBlock;
 import org.embeddedt.embeddium.render.fluid.EmbeddiumFluidSpriteCache;
 import repack.joml.Vector3d;
-
-import java.util.Objects;
 
 public class FluidRenderer {
 
@@ -72,16 +66,16 @@ public class FluidRenderer {
     }
 
     private boolean isFluidOccluded(IBlockAccess world, int x, int y, int z, EnumFacing dir, Fluid fluid) {
-        BlockPos pos = this.scratchPos.setPos(x, y, z);
+        BlockPos pos = this.scratchPos.setPos(x, y, z).toImmutable();
         IBlockState blockState = world.getBlockState(pos);
         BlockPos adjPos = this.scratchPos.setPos(x + dir.getXOffset(), y + dir.getYOffset(), z + dir.getZOffset());
-        Fluid adjFluid = WorldUtil.getFluid(world.getBlockState(adjPos));
+        Fluid adjFluid = WorldUtil.getFluid(WorldUtil.getFluidFromWorld(world, adjPos));
 
         if (blockState.getMaterial().isOpaque()) {
-            return fluid == adjFluid || blockState.isSideSolid(world,pos,dir);
+            return WorldUtil.isSame(fluid, adjFluid) || blockState.isSideSolid(world,pos,dir);
             // fluidlogged or next to water, occlude sides that are solid or the same liquid
         }
-        return fluid == adjFluid;
+        return WorldUtil.isSame(fluid, adjFluid);
     }
 
     private boolean isSideExposed(IBlockAccess world, int x, int y, int z, EnumFacing dir) {
@@ -125,7 +119,8 @@ public class FluidRenderer {
 
         TextureAtlasSprite[] sprites = fluidSpriteCache.getSprites(fluid);
         // Treat any non-lava fluid as colored, fluids without color providers will just use -1 which is a fine default
-        boolean hc = fluidState.getBlock() != Blocks.LAVA && fluidState.getBlock() != Blocks.FLOWING_LAVA;
+        // Currently disabled, as certain mods allow the lava fluid to be colored
+        boolean hc = true; // boolean hc = fluidState.getBlock() != Blocks.LAVA && fluidState.getBlock() != Blocks.FLOWING_LAVA;
 
         boolean rendered = false;
 
@@ -208,7 +203,7 @@ public class FluidRenderer {
             this.calculateQuadColors(quad, world, pos, lighter, EnumFacing.UP, 1.0F, hc);
             this.flushQuad(buffers, quad, facing, false);
 
-            if (WorldUtil.method_15756(world, this.scratchPos.setPos(posX, posY + 1, posZ), fluid)) {
+            if (WorldUtil.shouldRenderSides(world, this.scratchPos.setPos(posX, posY + 1, posZ), fluid)) {
                 this.setVertex(quad, 3, 0.0f, h1, 0.0f, u1, v1);
                 this.setVertex(quad, 2, 0.0f, h2, 1.0F, u2, v2);
                 this.setVertex(quad, 1, 1.0F, h3, 1.0F, u3, v3);
@@ -363,7 +358,7 @@ public class FluidRenderer {
         int[] biomeColors = null;
 
         if (colorized) {
-            IBlockState state = world.getBlockState(pos);
+            IBlockState state = WorldUtil.getFluidFromWorld(world, pos);
             IBlockColor colorProvider = ((BlockColorsExtended)this.vanillaBlockColors).getColorProvider(state);
             boolean containsColoredQuad = false;
             if(colorProvider != null) {
@@ -441,17 +436,17 @@ public class FluidRenderer {
             int x2 = x - (i & 1);
             int z2 = z - (i >> 1 & 1);
 
-            Block block = world.getBlockState(this.scratchPos.setPos(x2, y + 1, z2)).getBlock();
-            if (WorldUtil.getFluidOfBlock(block) == fluid) {
+            IBlockState above = WorldUtil.getFluidFromWorld(world, this.scratchPos.setPos(x2, y + 1, z2));
+            if (WorldUtil.isSame(fluid, WorldUtil.getFluid(above))) {
                 return 1.0F;
             }
 
-            BlockPos pos = this.scratchPos.setPos(x2, y, z2);
+            this.scratchPos.setY(y);
 
-            IBlockState blockState = world.getBlockState(pos);
-            Fluid fluid2 = WorldUtil.getFluidOfBlock(blockState.getBlock());
+            IBlockState blockState = WorldUtil.getFluidFromWorld(world, this.scratchPos);
+            Fluid fluid2 = WorldUtil.getFluid(blockState);
 
-            if (fluid == fluid2) {
+            if (WorldUtil.isSame(fluid, fluid2)) {
                 float height = WorldUtil.getFluidHeight(fluid2, blockState.getValue(BlockLiquid.LEVEL));
 
                 if (height >= 0.8F) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/SodiumBlockAccess.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/SodiumBlockAccess.java
@@ -3,10 +3,11 @@ package me.jellysquid.mods.sodium.client.world;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.biome.BiomeColorHelper;
+import org.embeddedt.embeddium.compat.fluidlogged_api.FluidloggedBlockAccess;
 
 /**
  * Contains extensions to the vanilla {@link IBlockAccess}.
  */
-public interface SodiumBlockAccess extends IBlockAccess {
+public interface SodiumBlockAccess extends IBlockAccess, FluidloggedBlockAccess {
     int getBlockTint(BlockPos pos, BiomeColorHelper.ColorResolver resolver);
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client.world;
 
+import git.jbredwards.fluidlogged_api.api.util.FluidState;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import me.jellysquid.mods.sodium.client.util.math.ChunkSectionPos;
 import me.jellysquid.mods.sodium.client.world.biome.BiomeColorCache;
@@ -14,7 +15,6 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.EnumSkyBlock;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldType;
 import net.minecraft.world.biome.Biome;
@@ -23,6 +23,8 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import net.minecraft.world.gen.structure.StructureBoundingBox;
 import net.minecraftforge.client.model.pipeline.LightUtil;
+import net.minecraftforge.fml.common.Optional;
+import org.embeddedt.embeddium.compat.fluidlogged_api.FluidloggedCompat;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -71,6 +73,9 @@ public class WorldSlice implements SodiumBlockAccess {
 
     // Local Section->BlockState table.
     private final IBlockState[][] blockStatesArrays;
+
+    // Local Section->FluidState table.
+    private final Object[][] fluidStatesArrays;
 
     // Local section copies. Read-only.
     private ClonedChunkSection[] sections;
@@ -148,6 +153,9 @@ public class WorldSlice implements SodiumBlockAccess {
         this.blockStatesArrays = new IBlockState[SECTION_TABLE_ARRAY_SIZE][];
         this.biomeCaches = new Biome[SECTION_TABLE_ARRAY_SIZE][16 * 16];
 
+        if(!FluidloggedCompat.IS_LOADED) this.fluidStatesArrays = null;
+        else this.fluidStatesArrays = new Object[SECTION_TABLE_ARRAY_SIZE][];
+
         for (int x = 0; x < SECTION_LENGTH; x++) {
             for (int y = 0; y < SECTION_LENGTH; y++) {
                 for (int z = 0; z < SECTION_LENGTH; z++) {
@@ -155,6 +163,11 @@ public class WorldSlice implements SodiumBlockAccess {
 
                     this.blockStatesArrays[i] = new IBlockState[SECTION_BLOCK_COUNT];
                     Arrays.fill(this.blockStatesArrays[i], Blocks.AIR.getDefaultState());
+
+                    if (FluidloggedCompat.IS_LOADED) {
+                        this.fluidStatesArrays[i] = new Object[SECTION_BLOCK_COUNT];
+                        Arrays.fill(this.fluidStatesArrays[i], FluidloggedCompat.getEmptyFluidState());
+                    }
                 }
             }
         }
@@ -183,32 +196,33 @@ public class WorldSlice implements SodiumBlockAccess {
 
                     this.biomeCaches[idx] = section.getBiomeData();
 
-                    this.unpackBlockData(this.blockStatesArrays[idx], section, context.getVolume());
+                    this.unpackBlockData(idx, section, context.getVolume());
                 }
             }
         }
     }
 
-    private void unpackBlockData(IBlockState[] states, ClonedChunkSection section, StructureBoundingBox box) {
+    private void unpackBlockData(int sectionIdx, ClonedChunkSection section, StructureBoundingBox box) {
         if (this.origin.equals(section.getPosition()))  {
-            this.unpackBlockDataZ(states, section);
+            this.unpackBlockDataZ(sectionIdx, section);
         } else {
-            this.unpackBlockDataR(states, section, box);
+            this.unpackBlockDataR(sectionIdx, section, box);
         }
     }
 
-    private static void copyBlocks(IBlockState[] blocks, ClonedChunkSection section, int minBlockY, int maxBlockY, int minBlockZ, int maxBlockZ, int minBlockX, int maxBlockX) {
+    private void copyBlocks(int sectionIdx, ClonedChunkSection section, int minBlockY, int maxBlockY, int minBlockZ, int maxBlockZ, int minBlockX, int maxBlockX) {
         for (int y = minBlockY; y <= maxBlockY; y++) {
             for (int z = minBlockZ; z <= maxBlockZ; z++) {
                 for (int x = minBlockX; x <= maxBlockX; x++) {
                     final int blockIdx = getLocalBlockIndex(x & 15, y & 15, z & 15);
-                    blocks[blockIdx] = section.getBlockState(x & 15, y & 15, z & 15);
+                    this.blockStatesArrays[sectionIdx][blockIdx] = section.getBlockState(x & 15, y & 15, z & 15);
+                    if (FluidloggedCompat.IS_LOADED) this.fluidStatesArrays[sectionIdx][blockIdx] = section.getFluidState(x & 15, y & 15, z & 15);
                 }
             }
         }
     }
 
-    private void unpackBlockDataR(IBlockState[] states, ClonedChunkSection section, StructureBoundingBox box) {
+    private void unpackBlockDataR(int sectionIdx, ClonedChunkSection section, StructureBoundingBox box) {
         ChunkSectionPos pos = section.getPosition();
 
         int minBlockX = Math.max(box.minX, pos.getMinX());
@@ -220,10 +234,10 @@ public class WorldSlice implements SodiumBlockAccess {
         int minBlockZ = Math.max(box.minZ, pos.getMinZ());
         int maxBlockZ = Math.min(box.maxZ, pos.getMaxZ());
 
-        copyBlocks(states, section, minBlockY, maxBlockY, minBlockZ, maxBlockZ, minBlockX, maxBlockX);
+        copyBlocks(sectionIdx, section, minBlockY, maxBlockY, minBlockZ, maxBlockZ, minBlockX, maxBlockX);
     }
 
-    private void unpackBlockDataZ(IBlockState[] states, ClonedChunkSection section) {
+    private void unpackBlockDataZ(int sectionIdx, ClonedChunkSection section) {
         // TODO: Look into a faster copy for this?
         final ChunkSectionPos pos = section.getPosition();
 
@@ -237,7 +251,7 @@ public class WorldSlice implements SodiumBlockAccess {
         final int maxBlockZ = pos.getMaxZ();
 
         // TODO: Can this be optimized?
-        copyBlocks(states, section, minBlockY, maxBlockY, minBlockZ, maxBlockZ, minBlockX, maxBlockX);
+        copyBlocks(sectionIdx, section, minBlockY, maxBlockY, minBlockZ, maxBlockZ, minBlockX, maxBlockX);
     }
 
     private static boolean blockBoxContains(StructureBoundingBox box, int x, int y, int z) {
@@ -269,8 +283,7 @@ public class WorldSlice implements SodiumBlockAccess {
         int relY = y - this.baseY;
         int relZ = z - this.baseZ;
 
-        return this.blockStatesArrays[getLocalSectionIndex(relX >> 4, relY >> 4, relZ >> 4)]
-                [getLocalBlockIndex(relX & 15, relY & 15, relZ & 15)];
+        return getBlockStateRelative(relX, relY, relZ);
     }
 
     public IBlockState getBlockStateRelative(int x, int y, int z) {
@@ -331,7 +344,8 @@ public class WorldSlice implements SodiumBlockAccess {
 
         IBlockState state = this.getBlockStateRelative(relX, relY, relZ);
 
-        if(!state.useNeighborBrightness()) {
+        if(!state.useNeighborBrightness()
+        && !(FluidloggedCompat.IS_LOADED && FluidloggedCompat.getFluidStateRelative(this, relX, relY, relZ).useNeighborBrightness())) {
             return getLightFor(type, relX, relY, relZ);
         } else {
             int west = getLightFor(type, relX - 1, relY, relZ);
@@ -405,8 +419,8 @@ public class WorldSlice implements SodiumBlockAccess {
 
     @Override
     public int getStrongPower(BlockPos pos, EnumFacing direction) {
-        IBlockState state = this.getBlockState(pos);
-        return state.getBlock().getStrongPower(state, this, pos, direction);
+        if (FluidloggedCompat.IS_LOADED) return FluidloggedCompat.getStrongPower(this, pos, direction);
+        else return this.getBlockState(pos).getStrongPower(this, pos, direction);
     }
 
     @Override
@@ -458,5 +472,32 @@ public class WorldSlice implements SodiumBlockAccess {
 
     public static int getLocalChunkIndex(int x, int z) {
         return z << TABLE_BITS | x;
+    }
+
+    @Override
+    @Optional.Method(modid = FluidloggedCompat.MODID)
+    public FluidState getFluidState(int x, int y, int z) {
+        if (!blockBoxContains(this.volume, x, y, z)) {
+            return FluidState.EMPTY;
+        }
+
+        int relX = x - this.baseX;
+        int relY = y - this.baseY;
+        int relZ = z - this.baseZ;
+
+        return getFluidStateRelative(relX, relY, relZ);
+    }
+
+    @Optional.Method(modid = FluidloggedCompat.MODID)
+    public FluidState getFluidStateRelative(int x, int y, int z) {
+        // NOTE: Not bounds checked. We assume ChunkRenderRebuildTask is the only function using this
+        return (FluidState) this.fluidStatesArrays[getLocalSectionIndex(x >> 4, y >> 4, z >> 4)]
+                [getLocalBlockIndex(x & 15, y & 15, z & 15)];
+    }
+
+    @Override
+    @Optional.Method(modid = FluidloggedCompat.MODID)
+    public World getWorld() {
+        return this.world;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSliceLocal.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSliceLocal.java
@@ -1,13 +1,17 @@
 package me.jellysquid.mods.sodium.client.world;
 
+import git.jbredwards.fluidlogged_api.api.util.FluidState;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 import net.minecraft.world.WorldType;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeColorHelper;
+import net.minecraftforge.fml.common.Optional;
+import org.embeddedt.embeddium.compat.fluidlogged_api.FluidloggedCompat;
 
 import javax.annotation.Nullable;
 
@@ -66,5 +70,17 @@ public class WorldSliceLocal implements SodiumBlockAccess {
     @Override
     public int getBlockTint(BlockPos pos, BiomeColorHelper.ColorResolver resolver) {
         return view.getBlockTint(pos, resolver);
+    }
+
+    @Override
+    @Optional.Method(modid = FluidloggedCompat.MODID)
+    public FluidState getFluidState(int x, int y, int z) {
+        return view.getFluidState(x, y, z);
+    }
+
+    @Override
+    @Optional.Method(modid = FluidloggedCompat.MODID)
+    public World getWorld() {
+        return view.getWorld();
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/cloned/ClonedChunkSection.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/cloned/ClonedChunkSection.java
@@ -13,6 +13,8 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.NibbleArray;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import net.minecraft.world.gen.structure.StructureBoundingBox;
+import org.embeddedt.embeddium.compat.fluidlogged_api.FluidStateStorage;
+import org.embeddedt.embeddium.compat.fluidlogged_api.FluidloggedCompat;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,6 +31,7 @@ public class ClonedChunkSection {
     private ChunkSectionPos pos;
 
     private ExtendedBlockStorage data;
+    private FluidStateStorage fluidData;
 
     private Biome[] biomeData;
 
@@ -53,6 +56,10 @@ public class ClonedChunkSection {
 
         if (section == Chunk.NULL_BLOCK_STORAGE/*ChunkSection.isEmpty(section)*/) {
             section = EMPTY_SECTION;
+        }
+
+        if (FluidloggedCompat.IS_LOADED) {
+            this.fluidData = new FluidStateStorage(chunk, ChunkSectionPos.getBlockCoord(pos.getY()));
         }
 
         this.pos = pos;
@@ -85,6 +92,10 @@ public class ClonedChunkSection {
 
     public IBlockState getBlockState(int x, int y, int z) {
         return data.get(x, y, z);
+    }
+
+    public Object getFluidState(int x, int y, int z) {
+        return fluidData.get(x, y, z);
     }
 
     public Biome getBiomeForNoiseGen(int x, int z) {

--- a/src/main/java/me/jellysquid/mods/sodium/common/util/WorldUtil.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/util/WorldUtil.java
@@ -9,7 +9,9 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.IFluidBlock;
+import org.embeddedt.embeddium.compat.fluidlogged_api.FluidloggedCompat;
 import repack.joml.Vector3d;
 
 /**
@@ -45,7 +47,7 @@ public class WorldUtil {
             }
         }
 
-        IBlockState state = world.getBlockState(pos);
+        IBlockState state = WorldUtil.getFluidFromWorld(world, pos);
         if (state.getValue(BlockLiquid.LEVEL) >= 8) {
             if (thizz.isSideSolid(world, pos.north(), EnumFacing.NORTH)
                     || thizz.isSideSolid(world, pos.south(), EnumFacing.SOUTH)
@@ -65,14 +67,14 @@ public class WorldUtil {
     }
 
     /**
-     * Returns true if any block in a 3x3x3 cube is not the same fluid and not an opaque full cube.
-     * Equivalent to FluidState::method_15756 in modern.
+     * Returns true if any block in a 3x1x3 area is not the same fluid and not a full block.
+     * Equivalent to BlockLiquid::shouldRenderSides, or FluidState::method_15756 in modern.
      */
-    public static boolean method_15756(IBlockAccess world, BlockPos pos, Fluid fluid) {
-        for (int i = 0; i < 2; ++i) {
-            for (int j = 0; j < 2; ++j) {
-                IBlockState block = world.getBlockState(pos);
-                if (!block.isOpaqueCube() && getFluid(block) != fluid) {
+    public static boolean shouldRenderSides(IBlockAccess world, BlockPos pos, Fluid fluid) {
+        for (int i = -1; i < 2; ++i) {
+            for (int j = -1; j < 2; ++j) {
+                IBlockState block = getFluidFromWorld(world, pos.add(i, 0, j));
+                if (!block.isFullBlock() && !isSame(getFluid(block), fluid)) {
                     return true;
                 }
             }
@@ -93,8 +95,8 @@ public class WorldUtil {
      * value of zero
      */
     public static int getEffectiveFlowDecay(IBlockAccess world, BlockPos pos, IBlockState thiz) {
-        IBlockState state = world.getBlockState(pos);
-        if (state.getMaterial() != thiz.getMaterial()) {
+        IBlockState state = getFluidFromWorld(world, pos);
+        if (!isSame(getFluid(thiz), getFluid(state))) {
             return -1;
         } else {
             int decay = state.getValue(BlockLiquid.LEVEL);
@@ -110,23 +112,34 @@ public class WorldUtil {
 
     public static Fluid getFluid(IBlockState b) {
         IFluidBlock fluidBlock = toFluidBlock(b.getBlock());
-        return fluidBlock != null ? fluidBlock.getFluid() : null;
+        if (fluidBlock != null) return fluidBlock.getFluid();
+
+        Material m = b.getMaterial();
+        return m == Material.WATER ? FluidRegistry.WATER : m == Material.LAVA ? FluidRegistry.LAVA : null;
+    }
+
+    public static IBlockState getFluidFromWorld(IBlockAccess world, BlockPos pos) {
+        return FluidloggedCompat.IS_LOADED ? FluidloggedCompat.getFluidOrReal(world, pos) : world.getBlockState(pos);
+    }
+
+    public static boolean isSame(Fluid fluid, Fluid otherFluid) {
+        return FluidloggedCompat.IS_LOADED ? FluidloggedCompat.isCompatibleFluid(fluid, otherFluid) : fluid == otherFluid;
     }
 
     /**
      * Equivalent to method_15748 in 1.16.5
      */
     public static boolean isEmptyOrSame(Fluid fluid, Fluid otherFluid) {
-        return otherFluid == null || fluid == otherFluid;
+        return otherFluid == null || isSame(fluid, otherFluid);
     }
 
     /**
      * Equivalent to method_15749 in 1.16.5
      */
     public static boolean method_15749(IBlockAccess world, Fluid thiz, BlockPos pos, EnumFacing dir) {
-        IBlockState b = world.getBlockState(pos);
+        IBlockState b = getFluidFromWorld(world, pos);
         Fluid f = getFluid(b);
-        if (f == thiz) {
+        if (isSame(f, thiz)) {
             return false;
         }
         if (dir == EnumFacing.UP) {
@@ -136,17 +149,17 @@ public class WorldUtil {
     }
 
     public static IFluidBlock toFluidBlock(Block block) {
-        if(block instanceof VanillaFluidBlock) {
+        if(block instanceof IFluidBlock) {
+            return (IFluidBlock) block;
+        } else if(block instanceof VanillaFluidBlock) {
             return ((VanillaFluidBlock) block).getFakeFluidBlock();
-        } else if(block instanceof IFluidBlock) {
-            return (IFluidBlock)block;
         } else {
             return null;
         }
     }
 
+    @Deprecated // Use state-sensitive method instead.
     public static Fluid getFluidOfBlock(Block block) {
-        IFluidBlock fluidBlock = toFluidBlock(block);
-        return fluidBlock != null ? fluidBlock.getFluid() : null;
+        return getFluid(block.getDefaultState());
     }
 }

--- a/src/main/java/org/embeddedt/embeddium/compat/fluidlogged_api/FluidStateStorage.java
+++ b/src/main/java/org/embeddedt/embeddium/compat/fluidlogged_api/FluidStateStorage.java
@@ -3,23 +3,31 @@ package org.embeddedt.embeddium.compat.fluidlogged_api;
 import git.jbredwards.fluidlogged_api.api.capability.IFluidStateCapability;
 import git.jbredwards.fluidlogged_api.api.capability.IFluidStateContainer;
 import git.jbredwards.fluidlogged_api.api.util.FluidState;
+import net.minecraft.world.chunk.BlockStateContainer;
 import net.minecraft.world.chunk.Chunk;
 
 import java.util.Objects;
 
 /**
- * Wrapper class for {@link IFluidStateContainer}.
+ * Holds a 16x16x16 copy of {@link IFluidStateContainer} data.
  */
 public class FluidStateStorage {
-    private final IFluidStateContainer container;
-    private final int containerY;
+    private final BlockStateContainer data = new BlockStateContainer();
 
-    public FluidStateStorage(Chunk chunk, int y) {
-        container = Objects.requireNonNull(IFluidStateCapability.get(chunk)).getContainer(y);
-        containerY = y;
+    public FluidStateStorage(Chunk chunkIn, int yIn) {
+        IFluidStateContainer container = Objects.requireNonNull(IFluidStateCapability.get(chunkIn)).getContainer(yIn);
+        container.forEach((pos, fluidState) -> {
+            int y = container.deserializeY(pos);
+            if (y >> 4 == yIn >> 4) {
+                int x = container.deserializeX(pos);
+                int z = container.deserializeZ(pos);
+
+                data.set(x & 15, y & 15, z & 15, fluidState.getState());
+            }
+        });
     }
 
     public Object get(int x, int y, int z) {
-        return container.getFluidState(x, containerY | y, z, FluidState.EMPTY);
+        return FluidState.of(data.get(x, y, z));
     }
 }

--- a/src/main/java/org/embeddedt/embeddium/compat/fluidlogged_api/FluidStateStorage.java
+++ b/src/main/java/org/embeddedt/embeddium/compat/fluidlogged_api/FluidStateStorage.java
@@ -1,0 +1,25 @@
+package org.embeddedt.embeddium.compat.fluidlogged_api;
+
+import git.jbredwards.fluidlogged_api.api.capability.IFluidStateCapability;
+import git.jbredwards.fluidlogged_api.api.capability.IFluidStateContainer;
+import git.jbredwards.fluidlogged_api.api.util.FluidState;
+import net.minecraft.world.chunk.Chunk;
+
+import java.util.Objects;
+
+/**
+ * Wrapper class for {@link IFluidStateContainer}.
+ */
+public class FluidStateStorage {
+    private final IFluidStateContainer container;
+    private final int containerY;
+
+    public FluidStateStorage(Chunk chunk, int y) {
+        container = Objects.requireNonNull(IFluidStateCapability.get(chunk)).getContainer(y);
+        containerY = y;
+    }
+
+    public Object get(int x, int y, int z) {
+        return container.getFluidState(x, containerY | y, z, FluidState.EMPTY);
+    }
+}

--- a/src/main/java/org/embeddedt/embeddium/compat/fluidlogged_api/FluidloggedBlockAccess.java
+++ b/src/main/java/org/embeddedt/embeddium/compat/fluidlogged_api/FluidloggedBlockAccess.java
@@ -1,0 +1,25 @@
+package org.embeddedt.embeddium.compat.fluidlogged_api;
+
+import git.jbredwards.fluidlogged_api.api.util.FluidState;
+import git.jbredwards.fluidlogged_api.api.world.IFluidStateProvider;
+import git.jbredwards.fluidlogged_api.api.world.IWorldProvider;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Optional;
+
+/**
+ * Allows Fluidlogged API to make use of Sodium's optimizations.
+ */
+@Optional.InterfaceList({
+@Optional.Interface(modid = FluidloggedCompat.MODID, iface = "git.jbredwards.fluidlogged_api.api.world.IFluidStateProvider"),
+@Optional.Interface(modid = FluidloggedCompat.MODID, iface = "git.jbredwards.fluidlogged_api.api.world.IWorldProvider")
+})
+public interface FluidloggedBlockAccess extends IBlockAccess, IFluidStateProvider, IWorldProvider {
+    @Override
+    @Optional.Method(modid = FluidloggedCompat.MODID)
+    FluidState getFluidState(int x, int y, int z);
+
+    @Override
+    @Optional.Method(modid = FluidloggedCompat.MODID)
+    World getWorld();
+}

--- a/src/main/java/org/embeddedt/embeddium/compat/fluidlogged_api/FluidloggedCompat.java
+++ b/src/main/java/org/embeddedt/embeddium/compat/fluidlogged_api/FluidloggedCompat.java
@@ -1,0 +1,78 @@
+package org.embeddedt.embeddium.compat.fluidlogged_api;
+
+import git.jbredwards.fluidlogged_api.api.block.IFluidloggable;
+import git.jbredwards.fluidlogged_api.api.util.FluidState;
+import git.jbredwards.fluidlogged_api.api.util.FluidloggedUtils;
+import git.jbredwards.fluidlogged_api.mod.asm.plugins.vanilla.world.PluginWorld;
+import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
+import me.jellysquid.mods.sodium.client.render.pipeline.context.ChunkRenderCacheLocal;
+import me.jellysquid.mods.sodium.client.util.MathUtil;
+import me.jellysquid.mods.sodium.client.world.WorldSlice;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumBlockRenderType;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.ForgeHooksClient;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fml.common.Loader;
+
+/**
+ * Contains methods used for Fluidlogged API compatibility.
+ */
+public class FluidloggedCompat {
+    public static final String MODID = "fluidlogged_api";
+    public static final boolean IS_LOADED = Loader.isModLoaded(MODID);
+
+    public static Object getEmptyFluidState() {
+        return FluidState.EMPTY;
+    }
+
+    public static IBlockState getFluidOrReal(IBlockAccess access, BlockPos pos) {
+        return FluidloggedUtils.getFluidOrReal(access, pos);
+    }
+
+    public static IBlockState getFluidStateRelative(WorldSlice slice, int relX, int relY, int relZ) {
+        return slice.getFluidStateRelative(relX, relY, relZ).getState();
+    }
+
+    public static int getStrongPower(IBlockAccess access, BlockPos pos, EnumFacing direction) {
+        // NOTE: This method may cause crashes when using a version of Fluidlogged API older than v3.0.5
+        return PluginWorld.Hooks.getStrongPower(access, pos, direction);
+    }
+
+    public static boolean isCompatibleFluid(Fluid fluid1, Fluid fluid2) {
+        return FluidloggedUtils.isCompatibleFluid(fluid1, fluid2);
+    }
+
+    public static boolean renderFluidState(WorldSlice slice, int relX, int relY, int relZ, BlockPos pos, IBlockState state, ChunkRenderCacheLocal cache, ChunkBuildBuffers buffers) {
+        boolean render = false;
+
+        FluidState fluidState = slice.getFluidStateRelative(relX, relY, relZ);
+        if (fluidState != FluidState.EMPTY && (!(state.getBlock() instanceof IFluidloggable) || ((IFluidloggable)state.getBlock()).shouldFluidRender(cache.getLocalSlice(), pos, state, fluidState))) {
+            IBlockAccess access = cache.getLocalSlice();
+            IBlockState renderState = fluidState.getState().getActualState(access, pos);
+
+            // renders the fluid in each layer
+            EnumBlockRenderType renderType = renderState.getRenderType();
+            for (BlockRenderLayer layer : BlockRenderLayer.values()) {
+                if (!renderState.getBlock().canRenderInLayer(renderState, layer)) continue;
+
+                ForgeHooksClient.setRenderLayer(layer);
+                if (renderType == EnumBlockRenderType.MODEL) render |= cache.getBlockRenderer().renderModel(
+                        access, renderState.getBlock().getExtendedState(renderState, access, pos), pos,
+                        cache.getBlockModels().getModelForState(renderState), buffers.get(layer), true,
+                        MathUtil.hashPos(pos));
+
+                else if (renderType == EnumBlockRenderType.LIQUID) render |= cache.getFluidRenderer().render(
+                        access, renderState, pos, buffers.get(layer));
+            }
+
+            // reset current render layer
+            ForgeHooksClient.setRenderLayer(null);
+        }
+
+        return render;
+    }
+}


### PR DESCRIPTION
This fixes [Fluidlogged-API#229](https://github.com/jbredwards/Fluidlogged-API/issues/229) and [Vintagium#6](https://github.com/Asek3/sodium-1.12/issues/6), while keeping Fluidlogged API to only an optional dependency.

---

Bug Fixes:
- FluidStates now render!
- `FluidRenderer` now accounts for FluidStates.
- `ChunkRenderRebuildTask` no longer forces fluid blocks to render using the `FluidRenderer`. This fixes the following issues:
    - Conflicts with blocks that require a non-vanilla model to render (gaseous fluids, finite fluids, and [Betweenlands'](https://www.curseforge.com/minecraft/mc-mods/angry-pixel-the-betweenlands-mod) "pseudo-fluidlogged" blocks).
    - Conflicts with Fluidlogged API's "fancy fluid rendering" setting.
    - Conflicts with [MAGE](https://www.curseforge.com/minecraft/mc-mods/mage) and [SmoothWater](https://www.curseforge.com/minecraft/mc-mods/smoothwater).
- `WorldUtil.getFluid()` now accounts for states that have a material of water or lava. This fixes issues with water & lava not connecting to "pseudo-fluidlogged" blocks (like the blocks from [CoralReef](https://www.curseforge.com/minecraft/mc-mods/coralreef)).
- `WorldUtil.getFluidFromBlock()` has been deprecated (in favor of `WorldUtil.getFluid()`), as a block's material may change depending on the state.

---

Important changes to keep in mind to maintain compatibility in the future:
- All `IBlockAccess.getBlockState()` calls that expect a fluid block have been replaced with a new `WorldUtil.getFluidFromWorld()` method, to respect FluidStates.
- All `fluid == otherFluid` calls have been replaced with a new `WorldUtil.isSame()` method, to respect Fluidlogged API's "compatible fluids" system.